### PR TITLE
fix ci

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -148,6 +148,10 @@ class CliTest(TestCase):
         | AFG    | Afghanistan |
         | AGO    | Angola      |
         +--------+-------------+
-        """)[1:-1]
+        """).strip()
         self.assertIn(expected, stdout)
-        self.assertIn(expected, pyperclip.paste())
+        from_clip_board = pyperclip.paste()
+        print('')
+        print(from_clip_board)
+        print(expected)
+        self.assertIn(expected, from_clip_board)


### PR DESCRIPTION
diff --git a/tests/cli/test_clit.py b/tests/cli/test_cli.py
similarity index 95%
rename from tests/cli/test_clit.py
rename to tests/cli/test_cli.py
index 6c1587b..a6be53c 100644
--- a/tests/cli/test_clit.py
+++ b/tests/cli/test_cli.py
@@ -148,6 +148,10 @@ class CliTest(TestCase):
         | AFG    | Afghanistan |
         | AGO    | Angola      |
         +--------+-------------+
-        """)[1:-1]
+        """).strip()
         self.assertIn(expected, stdout)
-        self.assertIn(expected, pyperclip.paste())
+        from_clip_board = pyperclip.paste()
+        print('')
+        print(from_clip_board)
+        print(expected)
+        self.assertIn(expected, from_clip_board)
