### PR TITLE
[add] automatic cached mode

### DIFF
--- a/redasql/command.py
+++ b/redasql/command.py
@@ -61,7 +61,7 @@ class MainCommand:
         self.data_source: Optional[DataSourceResponse] = None
 
         data_source_list = self.client.get_data_sources()
-        self.complete_data.data_sources = [d.name for d in data_source_list]
+        self.complete_data.data_sources = data_source_list
         if data_source_name:
             self.execute_meta_command_handler(fr'\c {data_source_name}')
 
@@ -146,6 +146,9 @@ class MainCommand:
     def execute_query_handler(self, query: str):
         if not self.data_source:
             raise NoDataSourceError('Plz set datasource.(use \\c <data source name>)')
+
+        if self.data_source.is_cached_query_results:
+            query = re.sub('(query_\\d+)', r'cached_\1', query)
 
         query_result = self._execute_query(
             query=query,

--- a/redasql/completer.py
+++ b/redasql/completer.py
@@ -6,14 +6,15 @@ from typing import List
 
 from prompt_toolkit.completion import FuzzyWordCompleter
 from redasql.constants import FormatterType, CompleterType, SQL_KEYWORDS, OutputType
-from redasql.dto import SchemaResponse
+from redasql.dto import SchemaResponse, DataSourceResponse
+from redasql.constants import CACHED_RESULTS_PREFIX
 
 
 class CompleteData:
     def __init__(self):
         self.keywords = SQL_KEYWORDS
         self.schemas: List[SchemaResponse] = []
-        self.data_sources = []
+        self.data_sources: List[DataSourceResponse] = []
         self.formats = FormatterType.values()
         self.outputs = OutputType.values()
 
@@ -33,12 +34,21 @@ class CompleteData:
             item.name for item in Path('.').iterdir() if item.is_file()
         ]
 
+    @property
+    def data_source_names(self):
+        ds_names = []
+        for ds in self.data_sources:
+            ds_names.append(ds.name)
+            if 'results' == ds.type:
+                ds_names.append(f'{CACHED_RESULTS_PREFIX}{ds.name}')
+        return ds_names
+
     def get_completer_words(self):
         words = list(set(
                 self.column_names +
                 self.schema_names +
                 self.keywords +
-                self.data_sources +
+                self.data_source_names +
                 self.formats +
                 self.outputs +
                 self.local_files
@@ -50,7 +60,7 @@ class CompleteData:
         meta_dict.update({c: CompleterType.TABLE.value for c in self.schema_names})
         meta_dict.update({c: CompleterType.COLUMN.value for c in self.column_names})
         meta_dict.update({c: CompleterType.KEYWORD.value for c in self.keywords})
-        meta_dict.update({c: CompleterType.DATA_SOURCE.value for c in self.data_sources})
+        meta_dict.update({c: CompleterType.DATA_SOURCE.value for c in self.data_source_names})
         meta_dict.update({c: CompleterType.FORMAT.value for c in self.formats})
         meta_dict.update({c: CompleterType.OUTPUT.value for c in self.outputs})
         meta_dict.update({c: CompleterType.FILE.value for c in self.local_files})

--- a/redasql/constants.py
+++ b/redasql/constants.py
@@ -1,5 +1,8 @@
 import enum
 
+CACHED_RESULTS_PREFIX = 'cached_'
+CACHED_QUERY_RESULTS_TYPE = 'cached_results'
+
 
 class OperatorType(enum.Enum):
     REPLACE = 'replace'

--- a/redasql/dto.py
+++ b/redasql/dto.py
@@ -2,7 +2,7 @@ import datetime
 import dataclasses
 from typing import Optional, Any, List
 
-from redasql.constants import OperatorType
+from redasql.constants import OperatorType, CACHED_QUERY_RESULTS_TYPE
 
 
 @dataclasses.dataclass(frozen=True)
@@ -44,6 +44,10 @@ class DataSourceResponse:
     @property
     def is_query_results(self):
         return self.type in ('results', 'resultswithparams')
+
+    @property
+    def is_cached_query_results(self):
+        return self.type == CACHED_QUERY_RESULTS_TYPE
 
     @classmethod
     def from_response(cls, response: dict):


### PR DESCRIPTION
```
(No DataSource)=# \c cached_query_results
cached_query_results=# select count(*) from query_1 t1 join query_2 t2 on cast(t1.id as int) = cast(t2.id as int);

.```sql
select count(*) from cached_query_1 t1 join cached_query_2 t2 on cast(t1.id as int) = cast(t2.id as int);  <-- automatically add cached_
.```

|   count(*) |
|------------|
|        139 |

1 row returned.
Time: 1.6504s

```