### PR TITLE
[add] separator to pivoted markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,10 +263,12 @@ metadata=# select id, object_id, org_id, created_at from favorites limit 3;
 | org_id       | 1                        |
 | id           | 2                        |
 | object_id    | 513                      |
+| -----        | -----                    |
 | created_at   | 2019-05-22T05:30:19.031Z |
 | org_id       | 1                        |
 | id           | 3                        |
 | object_id    | 514                      |
+| -----        | -----                    |
 | created_at   | 2019-05-22T08:17:12.693Z |
 | org_id       | 1                        |
 | id           | 4                        |

--- a/redasql/constants.py
+++ b/redasql/constants.py
@@ -689,3 +689,5 @@ SQL_KEYWORDS = [
     'YEAR',
     'ZONE',
 ]
+
+ROW_SEPARATOR = '-' * 5

--- a/redasql/result_formatter.py
+++ b/redasql/result_formatter.py
@@ -7,6 +7,7 @@ import tabulate
 
 from redasql.constants import FormatterType, ROW_SEPARATOR
 from redasql.dto import QueryResultResponse
+from redasql.utils import signal_last
 
 tabulate.PRESERVE_WHITESPACE = True
 
@@ -81,10 +82,10 @@ class MarkdownFormatter(Formatter):
 
     def _format_result_to_column_base(self):
         row_for_tables = []
-        for i, row in enumerate(self.rows, 1):
+        for is_last_row, row in signal_last(self.rows):
             for column_name in self.column_name_list:
                 row_for_tables.append([column_name, self._replace_line_break(row[column_name])])
-            if i < len(self.rows):
+            if not is_last_row:
                 row_for_tables.append([ROW_SEPARATOR, ROW_SEPARATOR])
 
         table = tabulate.tabulate(

--- a/redasql/result_formatter.py
+++ b/redasql/result_formatter.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import tabulate
 
-from redasql.constants import FormatterType
+from redasql.constants import FormatterType, ROW_SEPARATOR
 from redasql.dto import QueryResultResponse
 
 tabulate.PRESERVE_WHITESPACE = True
@@ -85,7 +85,7 @@ class MarkdownFormatter(Formatter):
             for column_name in self.column_name_list:
                 row_for_tables.append([column_name, self._replace_line_break(row[column_name])])
             if i < len(self.rows):
-                row_for_tables.append(['-' * 5, '-' * 5])
+                row_for_tables.append([ROW_SEPARATOR, ROW_SEPARATOR])
 
         table = tabulate.tabulate(
             row_for_tables,

--- a/redasql/result_formatter.py
+++ b/redasql/result_formatter.py
@@ -81,9 +81,11 @@ class MarkdownFormatter(Formatter):
 
     def _format_result_to_column_base(self):
         row_for_tables = []
-        for row in self.rows:
+        for i, row in enumerate(self.rows, 1):
             for column_name in self.column_name_list:
                 row_for_tables.append([column_name, self._replace_line_break(row[column_name])])
+            if i < len(self.rows):
+                row_for_tables.append(['-' * 5, '-' * 5])
 
         table = tabulate.tabulate(
             row_for_tables,

--- a/redasql/utils.py
+++ b/redasql/utils.py
@@ -1,3 +1,6 @@
+from typing import Iterable, Any, Tuple
+
+
 def is_empty(target_str: str):
     return target_str.strip() == ''
 
@@ -8,3 +11,12 @@ def is_sql_end(target_str: str):
 
 def is_meta_command(target_str: str):
     return target_str.strip().startswith('\\')
+
+
+def signal_last(it:Iterable[Any]) -> Iterable[Tuple[bool, Any]]:
+    iterable = iter(it)
+    ret_var = next(iterable)
+    for val in iterable:
+        yield False, ret_var
+        ret_var = val
+    yield True, ret_var

--- a/tests/cli/test_result_formatter.py
+++ b/tests/cli/test_result_formatter.py
@@ -50,7 +50,11 @@ class FormatterTest(TestCase):
             query='select \'a\na\' col',
             runtime=0.1,
             data=QueryResultData(
-                rows=[{'col1': 'a\na', 'col2': 1}],
+                rows=[
+                    {'col1': 'a\na', 'col2': 1},
+                    {'col1': 'b\nb', 'col2': 2},
+                    {'col1': 'c\nc', 'col2': 3}
+                ],
                 columns=[
                     QueryResultColumn(
                         friendly_name='col1',
@@ -71,6 +75,12 @@ class FormatterTest(TestCase):
         | colum_name   | value   |
         |--------------|---------|
         | col1         | a<br/>a |
-        | col2         | 1       |""")
+        | col2         | 1       |
+        | -----        | -----   |
+        | col1         | b<br/>b |
+        | col2         | 2       |
+        | -----        | -----   |
+        | col1         | c<br/>c |
+        | col2         | 3       |""")
         print(formatted_string)
         self.assertEqual(formatted_string, expected)


### PR DESCRIPTION
Hi. Thank you for the very coolest library.
I'm a heavy user of redasql.

I often use markdown format, but when I pipvoted in markdown format, I found it difficult to understand the record-by-record separations.


| colum_name   | value                    |
|--------------|--------------------------|
| id           | 2                        |
| object_id    | 513                      |
| id           | 3                        |
| object_id    | 514                      |
| id           | 4                        |
| object_id    | 230                      |

So I fixed it to output a separator for each record.


| colum_name   | value                    |
|--------------|--------------------------|
| id           | 2                        |
| object_id    | 513                      |
| ----- | ----- |
| id           | 3                        |
| object_id    | 514                      |
| ----- | ----- |
| id           | 4                        |
| object_id    | 230                      |

